### PR TITLE
Associate loans to payment types

### DIFF
--- a/packages/graphql-types/types/Account.graphql
+++ b/packages/graphql-types/types/Account.graphql
@@ -55,6 +55,8 @@ interface Account {
   """
   availableBalance: Money
 
+  currency: Currency
+
   """
   The transactions for this account
   """
@@ -84,6 +86,7 @@ interface InternalAccount {
   accountNumberMasked: String
   actualBalance: Money
   availableBalance: Money
+  currency: Currency
   transactionConnection(
     limit: Int = 10
     categoryId: ID
@@ -121,6 +124,7 @@ type CheckingAccount implements Account & InternalAccount & InterestBearingAccou
   typeDescription: String
   actualBalance: Money
   availableBalance: Money
+  currency: Currency
   routingNumber: String
 
   transactionConnection(
@@ -157,6 +161,7 @@ type SavingsAccount implements Account & InternalAccount & InterestBearingAccoun
   typeDescription: String
   actualBalance: Money
   availableBalance: Money
+  currency: Currency
   routingNumber: String
   message: Message
 
@@ -197,6 +202,7 @@ type CertificateAccount implements Account & InternalAccount & InterestBearingAc
   typeDescription: String
   actualBalance: Money
   availableBalance: Money
+  currency: Currency
   routingNumber: String
   message: Message
 
@@ -232,6 +238,7 @@ type InvestmentAccount implements Account & InternalAccount & Node {
   typeDescription: String
   actualBalance: Money
   availableBalance: Money
+  currency: Currency
   routingNumber: String
 
   transactionConnection(
@@ -287,6 +294,7 @@ type LoanAccount implements Account & InternalAccount & AbstractLoanAccount & No
   typeDescription: String
   actualBalance: Money
   availableBalance: Money
+  currency: Currency
   routingNumber: String
   message: Message
   paymentOptions: [LoanPaymentOptions!]!
@@ -331,6 +339,7 @@ type LineOfCreditAccount implements Account & InternalAccount & AbstractLoanAcco
   typeDescription: String
   actualBalance: Money
   availableBalance: Money
+  currency: Currency
   routingNumber: String
   message: Message
   paymentOptions: [LoanPaymentOptions!]!
@@ -372,6 +381,7 @@ type CreditCardAccount implements Account & InternalAccount & AbstractLoanAccoun
   typeDescription: String
   actualBalance: Money
   availableBalance: Money
+  currency: Currency
   routingNumber: String
   message: Message
   paymentOptions: [LoanPaymentOptions!]!

--- a/packages/graphql-types/types/Account.graphql
+++ b/packages/graphql-types/types/Account.graphql
@@ -267,7 +267,7 @@ interface AbstractLoanAccount {
   originationDate: Date
   payoff: Money
   secured: Boolean
-  paymentOptions: [LoanPaymentOptions]
+  paymentOptions: [LoanPaymentOptions!]!
 }
 
 type LoanPaymentOptions {
@@ -289,7 +289,7 @@ type LoanAccount implements Account & InternalAccount & AbstractLoanAccount & No
   availableBalance: Money
   routingNumber: String
   message: Message
-  paymentOptions: [LoanPaymentOptions]
+  paymentOptions: [LoanPaymentOptions!]!
 
   transactionConnection(
     limit: Int = 10
@@ -333,7 +333,7 @@ type LineOfCreditAccount implements Account & InternalAccount & AbstractLoanAcco
   availableBalance: Money
   routingNumber: String
   message: Message
-  paymentOptions: [LoanPaymentOptions]
+  paymentOptions: [LoanPaymentOptions!]!
 
   transactionConnection(
     limit: Int = 10
@@ -374,7 +374,7 @@ type CreditCardAccount implements Account & InternalAccount & AbstractLoanAccoun
   availableBalance: Money
   routingNumber: String
   message: Message
-  paymentOptions: [LoanPaymentOptions]
+  paymentOptions: [LoanPaymentOptions!]!
 
   transactionConnection(
     limit: Int = 10

--- a/packages/graphql-types/types/Account.graphql
+++ b/packages/graphql-types/types/Account.graphql
@@ -267,6 +267,14 @@ interface AbstractLoanAccount {
   originationDate: Date
   payoff: Money
   secured: Boolean
+  paymentOptions: [LoanPaymentOptions]
+}
+
+type LoanPaymentOptions {
+  paymentType: PaymentType!
+  defaultValue: Money
+  value: Money
+  max: Money
 }
 
 type LoanAccount implements Account & InternalAccount & AbstractLoanAccount & Node {
@@ -281,6 +289,7 @@ type LoanAccount implements Account & InternalAccount & AbstractLoanAccount & No
   availableBalance: Money
   routingNumber: String
   message: Message
+  paymentOptions: [LoanPaymentOptions]
 
   transactionConnection(
     limit: Int = 10
@@ -324,6 +333,7 @@ type LineOfCreditAccount implements Account & InternalAccount & AbstractLoanAcco
   availableBalance: Money
   routingNumber: String
   message: Message
+  paymentOptions: [LoanPaymentOptions]
 
   transactionConnection(
     limit: Int = 10
@@ -364,6 +374,7 @@ type CreditCardAccount implements Account & InternalAccount & AbstractLoanAccoun
   availableBalance: Money
   routingNumber: String
   message: Message
+  paymentOptions: [LoanPaymentOptions]
 
   transactionConnection(
     limit: Int = 10

--- a/packages/graphql-types/types/User.graphql
+++ b/packages/graphql-types/types/User.graphql
@@ -56,9 +56,13 @@ type Relationship implements Node {
 type Customer implements Node {
   id: ID!
   name: String!
-  accounts: [InternalAccount!]!
+  accounts(filter: AccountsFilter): [InternalAccount!]!
   account(id: ID!): InternalAccount
   representative: Party!
+}
+
+input AccountsFilter {
+  transferFrom: Boolean
 }
 
 extend type Query {


### PR DESCRIPTION
# Issue
https://github.com/trabian/q2-sdk-tools/issues/51

# Motivation
Not all payments are valid on all loans. For instance, an escrow payment makes sense for a mortgage, but not when paying off a line of credit.

# Work done
* Snuck in an unrelated change - allow filtering a customers accounts by `transferFrom`
* Added schema to associate AbstractLoanAccounts to payment options
* Add `currency` to Accounts so that the balance numbers can be better interpreted.